### PR TITLE
Fix ImportError when an INSTALLED_APP is a dotted path to an AppConfig

### DIFF
--- a/crudbuilder/helpers.py
+++ b/crudbuilder/helpers.py
@@ -165,7 +165,7 @@ def import_crud(app):
 
     try:
         app_path = import_module(app).__path__
-    except AttributeError:
+    except (AttributeError, ImportError):
         return None
 
     try:


### PR DESCRIPTION
I have an `INSTALLED_APPS` setting which contains a dotted path to an AppConfig, like so:

```#!python
INSTALLED_APPS = [
    # some normal apps...,
    'myproject.myapp.MyAppConfig',
    # some more apps...,
]
```

Somehow the `import_module` inside the `import_crud` will raise an `ImportError`, even though Django manages to import it as an app. If we catch the `ImportError` here, `crudbuilder` will function as normal.

[Django docs on INSTALLED_APPS](https://docs.djangoproject.com/en/1.9/ref/settings/#installed-apps)