### PR TITLE
Custom url

### DIFF
--- a/crudbuilder/abstract.py
+++ b/crudbuilder/abstract.py
@@ -41,6 +41,7 @@ class BaseBuilder(object):
         self.custom_queryset = self._has_crud_attr('custom_queryset')
         self.custom_context = self._has_crud_attr('custom_context')
         self.inlineformset = self.get_inlineformset
+        self.custom_url_name = self._has_crud_attr('custom_url_name')
 
     @property
     def get_model_class(self):
@@ -84,7 +85,7 @@ class MetaCrudRegister(type):
     def __new__(cls, clsname, bases, attrs):
         newclass = super(
             MetaCrudRegister, cls
-            ).__new__(cls, clsname, bases, attrs)
+        ).__new__(cls, clsname, bases, attrs)
 
         if bases:
             if newclass.model:
@@ -98,3 +99,7 @@ class MetaCrudRegister(type):
 class BaseCrudBuilder(with_metaclass(MetaCrudRegister)):
     model = None
     inlineformset = None
+
+    @classmethod
+    def get_class_name(cls):
+        return cls.__name__.lower()

--- a/crudbuilder/registry.py
+++ b/crudbuilder/registry.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from crudbuilder.exceptions import(
+from crudbuilder.exceptions import (
     NotModelException,
     AlreadyRegistered,
     NotRegistered
@@ -47,24 +47,24 @@ class CrudBuilderRegistry(dict):
             msg = "First argument should be Django Model"
             raise NotModelException(msg)
 
-        key = self._model_key(model)
+        key = self._class_key(crudbuilder)
 
         if key in self:
             msg = "Key '{key}' has already been registered.".format(
                 key=key
-                )
+            )
             raise AlreadyRegistered(msg)
 
         self.__setitem__(key, crudbuilder)
         return crudbuilder
 
-    def _model_key(self, model):
-        app_label = model._meta.app_label
-        model_name = model.__name__.lower()
-        return '{}-{}'.format(app_label, model_name)
+    def _class_key(self, crudbuilder):
+        app_label = crudbuilder.model._meta.app_label
+        crud_class_name = crudbuilder.get_class_name()
+        return '{}-{}'.format(app_label, crud_class_name)
 
-    def unregister(self, model):
-        key = self._model_key(model)
+    def unregister(self, crudbuilder):
+        key = self._class_key(crudbuilder)
         if key in self:
             self.__delitem__(key)
 

--- a/crudbuilder/tests/crud.py
+++ b/crudbuilder/tests/crud.py
@@ -16,3 +16,8 @@ class TestModelCrud(BaseCrudBuilder):
     tables2_css_class = "table table-bordered table-condensed"
     tables2_pagination = 20  # default is 10
     modelform_excludes = ['created_by']
+
+
+class TestSameModelCrud(BaseCrudBuilder):
+    model = TestModel
+    custom_url_name = 'testfoo'

--- a/crudbuilder/tests/crud.py
+++ b/crudbuilder/tests/crud.py
@@ -18,6 +18,6 @@ class TestModelCrud(BaseCrudBuilder):
     modelform_excludes = ['created_by']
 
 
-class TestSameModelCrud(BaseCrudBuilder):
+class TestCustomURLModelCrud(BaseCrudBuilder):
     model = TestModel
-    custom_url_name = 'testfoo'
+    custom_url_name = 'foo'

--- a/crudbuilder/tests/test_views.py
+++ b/crudbuilder/tests/test_views.py
@@ -32,6 +32,11 @@ class ViewTestCase(TestCase):
         response = self.client.get(reverse('tests-testmodel-list'))
         self.assertEqual(200, response.status_code)
 
+    def test_custom_url_name(self):
+        self.client_login()
+        response = self.client.get(reverse('testfoo-list'))
+        self.assertEqual(200, response.status_code)
+
     def test_user_not_logged_in(self):
         response = self.client.get(reverse('tests-testmodel-list'))
         self.assertEqual(302, response.status_code)

--- a/crudbuilder/tests/test_views.py
+++ b/crudbuilder/tests/test_views.py
@@ -32,11 +32,6 @@ class ViewTestCase(TestCase):
         response = self.client.get(reverse('tests-testmodel-list'))
         self.assertEqual(200, response.status_code)
 
-    def test_custom_url_name(self):
-        self.client_login()
-        response = self.client.get(reverse('testfoo-list'))
-        self.assertEqual(200, response.status_code)
-
     def test_user_not_logged_in(self):
         response = self.client.get(reverse('tests-testmodel-list'))
         self.assertEqual(302, response.status_code)
@@ -155,3 +150,18 @@ class ViewTestCase(TestCase):
         c = Context({"obj": obj})
         result = t.render(c)
         self.assertEqual(result, 'object1')
+
+    def test_custom_url_name_list(self):
+        self.client_login()
+        response = self.client.get(reverse('foo-list'))
+        self.assertEqual(200, response.status_code)
+
+    def test_custom_url_name_create_url(self):
+        self.assertEqual('/crud/foo/create/', reverse('foo-create'))
+
+    def test_custom_url_name_update_url(self):
+        self.assertEqual('/crud/foo/1/update/', reverse('foo-update', args=[1]))
+
+    def test_custom_url_name_delete_url(self):
+        self.assertEqual('/crud/foo/1/delete/', reverse('foo-delete', args=[1]))
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -107,6 +107,7 @@ CRUD class Attributes
 - **custom_queryset** -- Define your own custom queryset for list view
 - **custom_context** -- Define your own custom context for list view
 - **inlineformset** -- Define your Inline Formset for parent child relation, you can check :doc:`inline-formset-parent-child-relation </forms>` for more detail.
+- **custom_url_name** -- Define your own custom model URL. For example instead of `/crud/<appname>/<modelname>/` it could be `/crud/foo/`
 
 Usage of all these attributes you can view in `CRUD class of example project`_ on Github.
 


### PR DESCRIPTION
I added parameter `custom_url_name`, which can be used to set custom URL, for example `/crud/foo/` instead of `/crud/<appname>/<modelname>/`. 
I had to redesign a bit registry part of code so it's not bound to model. I added some tests and updated docs, though it may need some polishing.