### PR TITLE
Form help text

### DIFF
--- a/crudbuilder/templates/crudbuilder/widgets/form.html
+++ b/crudbuilder/templates/crudbuilder/widgets/form.html
@@ -7,6 +7,9 @@
 			{{ field|label_with_class:"col-sm-2 control-label" }}
 			<div class="col-xs-4">
 				{{ field|input_with_class:"form-control" }}
+                {% if field.help_text %}
+                    <p class="help-block">{{ field.help_text|safe }}</p>
+                {% endif %}
 			    {{ field.errors }}
 			</div>
 		</fieldset>

--- a/crudbuilder/templates/crudbuilder/widgets/form.html
+++ b/crudbuilder/templates/crudbuilder/widgets/form.html
@@ -7,9 +7,9 @@
 			{{ field|label_with_class:"col-sm-2 control-label" }}
 			<div class="col-xs-4">
 				{{ field|input_with_class:"form-control" }}
-                {% if field.help_text %}
-                    <p class="help-block">{{ field.help_text|safe }}</p>
-                {% endif %}
+				{% if field.help_text %}
+					<p class="help-block">{{ field.help_text|safe }}</p>
+				{% endif %}
 			    {{ field.errors }}
 			</div>
 		</fieldset>


### PR DESCRIPTION
I noticed that crudbuilder form template is not rendering help text below fields. I added this feature.