### PR TITLE
Added support for custom CreateViews and UpdateViews

### DIFF
--- a/crudbuilder/abstract.py
+++ b/crudbuilder/abstract.py
@@ -1,4 +1,5 @@
 import django
+
 try:
     from django.apps import apps
 except ImportError:
@@ -14,10 +15,10 @@ from crudbuilder import helpers
 
 class BaseBuilder(object):
     def __init__(
-        self,
-        app,
-        model,
-        crud
+            self,
+            app,
+            model,
+            crud
     ):
 
         self.model = model
@@ -28,6 +29,9 @@ class BaseBuilder(object):
         self.modelform_excludes = self._has_crud_attr('modelform_excludes')
         self.detailview_excludes = self._has_crud_attr('detailview_excludes')
         self.createupdate_forms = self._has_crud_attr('createupdate_forms')
+
+        self.custom_update_view_mixin = self._has_crud_attr('custom_update_view_mixin')
+        self.custom_create_view_mixin = self._has_crud_attr('custom_create_view_mixin')
 
         # django tables2
         self.custom_table2 = self._has_crud_attr('custom_table2')

--- a/crudbuilder/views.py
+++ b/crudbuilder/views.py
@@ -127,9 +127,13 @@ class ViewBuilder(BaseBuilder):
             custom_postfix_url=self.custom_postfix_url
         )
 
+        parent_classes = [self.get_createupdate_mixin(), CreateView]
+        if self.custom_create_view_mixin:
+            parent_classes.insert(0, self.custom_create_view_mixin)
+
         create_class = type(
             name,
-            (self.get_createupdate_mixin(), CreateView),
+            tuple(parent_classes),
             create_args
         )
 
@@ -172,9 +176,13 @@ class ViewBuilder(BaseBuilder):
             custom_postfix_url=self.custom_postfix_url
         )
 
+        parent_classes = [self.get_createupdate_mixin(), UpdateView]
+        if self.custom_update_view_mixin:
+            parent_classes.insert(0, self.custom_update_view_mixin)
+
         update_class = type(
             name,
-            (self.get_createupdate_mixin(), UpdateView),
+            tuple(parent_classes),
             update_args
         )
         self.classes[name] = update_class


### PR DESCRIPTION
Hi asifpy,

first of all thanks for the awesome crudbuilder. I really like it and I am heavily using it.

I added a few lines of code that allow to customize the generated Update and Create Views by mixins. My concrete challenge was to add a custom get_success_url for Create and Update. However I did not want to write a custom view in a custom module and add it to the urls.py.

Instead I found it useful to just add a custom mixin for the create and update view:

https://gist.github.com/tonimichel/d2e96f6a20a8028ba5c5ab7c49a3ab02

We now can overwrite any class attribute and easily customize the generated view functions.
Of course we could also extends this principle to the detail, list and delete view.

Let me know if you like it.

Best regards from Stuttgart, Germany.
Toni

  