### PR TITLE
fixed cruds view app and model columns order using namedtuples

### DIFF
--- a/crudbuilder/templates/crudbuilder/cruds.html
+++ b/crudbuilder/templates/crudbuilder/cruds.html
@@ -17,9 +17,9 @@
 			{% for key, crud in view.cruds %}
 				<tr>
 					{% with detail=key|crud_detail %}
-						<td><a href="{% url detail.2 %}">{{crud|class_name}}</a></td>
-						<td>{{detail.0|title}}</td>
-						<td>{{detail.1|title}}</td>
+						<td><a href="{% url detail.postfix_url %}">{{crud|class_name}}</a></td>
+						<td>{{detail.model|title}}</td>
+						<td>{{detail.app|title}}</td>
 					{% endwith %}
 				</tr>
 			{% endfor %}

--- a/crudbuilder/templatetags/crudbuilder.py
+++ b/crudbuilder/templatetags/crudbuilder.py
@@ -12,6 +12,7 @@ except ImportError:
 
 register = template.Library()
 Field = namedtuple('Field', 'name verbose_name')
+CrudDetail = namedtuple('CrudListing', ['app', 'model', 'list_url'])
 
 
 @register.filter
@@ -37,7 +38,7 @@ def class_name(obj):
 def crud_detail(crud_key):
     app, model, postfix_url = crud_key.split('-', 2)
     list_url = '{}-{}-list'.format(app, postfix_url)
-    return (app, model, list_url)
+    return CrudDetail(app, model, list_url)
 
 
 @register.filter


### PR DESCRIPTION
I noticed the cruds index page had 'app' and 'model' columns swapped.  This pull request fixes this.  I found regular tuple indexing (0, 1, 2) hard to follow and namedtuples provide semantics making it an easy fix.

Please let me know if it looks good or anything needs further tweaking.