### PR TITLE
fixed misspelling of CrudDetail

### DIFF
--- a/crudbuilder/templatetags/crudbuilder.py
+++ b/crudbuilder/templatetags/crudbuilder.py
@@ -12,7 +12,7 @@ except ImportError:
 
 register = template.Library()
 Field = namedtuple('Field', 'name verbose_name')
-CrudDetail = namedtuple('CrudListing', ['app', 'model', 'list_url'])
+CrudDetail = namedtuple('CrudDetail', ['app', 'model', 'list_url'])
 
 
 @register.filter


### PR DESCRIPTION
It's not material, but I found a used the name CrudListing instead of CrudDetail in the namedtuple.  This is fixes that misspelling.