### PR TITLE
Updated requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Prerequisites
 -------------
 - Django 1.10+
 - Python 2.7+, 3.3+
-- Django Tables2
+- Django Tables2 < 2.0
 
 Installation
 ------------


### PR DESCRIPTION
There should be explicitly stated that crudbuilder is not compatible with django-tables2 version 2.0 and above.