### PR TITLE
Get CRUD name from Django model

### DIFF
--- a/crudbuilder/mixins.py
+++ b/crudbuilder/mixins.py
@@ -7,7 +7,6 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.conf import settings
 from django.contrib import messages
 
-from crudbuilder.helpers import plural
 from crudbuilder.signals import crudbuilder_signals
 
 if six.PY3:
@@ -81,11 +80,13 @@ class CrudBuilderMixin(LoginRequiredMixin, PermissionRequiredMixin):
             context['exclude'] = self.detailview_excludes
         except:
             context['exclude'] = None
-        context['actual_model_name'] = model.__name__.lower()
-        context['pluralized_model_name'] = plural(model.__name__.lower())
-        context['verbose_model_name'] = model._meta.verbose_name
+        name = model._meta.verbose_name
+        context['actual_model_name'] = name
+        context['verbose_model_name'] = name
+        name_plural = model._meta.verbose_name_plural
+        context['pluralized_model_name'] = name_plural
+        context['verbose_model_name_plural'] = name_plural
         context['custom_postfix_url'] = self.custom_postfix_url
-        context['verbose_model_name_plural'] = model._meta.verbose_name_plural
         context['project_name'] = getattr(
             settings, 'PROJECT_NAME', 'CRUDBUILDER')
         return context

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -34,6 +34,8 @@ We're going to run through creating a tutorial app. Let's start with a simple mo
         created_at = models.DateTimeField(auto_now=True)
         created_by = models.ForeignKey(User, blank=True, null=True)
 
+You can optionally set verbose_name and verbose_name_plural in model's Meta class to have custom name in CRUD interface.
+
 Then create the CRUD class for ``Person`` model::
 
     # tutorial/crud.py


### PR DESCRIPTION
I needed to change display name of Crud and only way I found was to modify template. But why is not the name of Crud taken directly from Django model verbose_name (plural)? This way there is no need to somehow generate it on Crudbuilder side.