### PR TITLE
Custom URL redirect after object is successfully created/updated

### DIFF
--- a/crudbuilder/abstract.py
+++ b/crudbuilder/abstract.py
@@ -52,6 +52,7 @@ class BaseBuilder(object):
         self.inlineformset = self.get_inlineformset
         self.custom_postfix_url = self.postfix_url
         self.custom_listview_obj = self._has_crud_attr('custom_listview_obj')
+        self.custom_get_success_url = self._has_crud_attr('get_success_url')
 
     @property
     def get_model_class(self):

--- a/crudbuilder/tests/crud.py
+++ b/crudbuilder/tests/crud.py
@@ -1,5 +1,6 @@
 from crudbuilder.abstract import BaseCrudBuilder
 from crudbuilder.formset import BaseInlineFormset
+from crudbuilder.helpers import reverse
 from crudbuilder.tests.models import TestModel, TestChildModel
 
 
@@ -16,3 +17,6 @@ class TestModelCrud(BaseCrudBuilder):
     tables2_css_class = "table table-bordered table-condensed"
     tables2_pagination = 20  # default is 10
     modelform_excludes = ['created_by']
+
+    def get_success_url(self):
+        return reverse('tests-testmodels-detail', args=(self.object.pk,))

--- a/crudbuilder/tests/test_views.py
+++ b/crudbuilder/tests/test_views.py
@@ -123,6 +123,25 @@ class ViewTestCase(TestCase):
         setattr(TestModelCrud, 'custom_context', classmethod(custom_context))
         self.get_list_view()
 
+    def test_custom_get_success_url(self):
+
+        TestModelCrud.createupdate_forms = dict(
+            create=TestModelForm,
+            update=TestModelForm)
+
+        self.client_login()
+        self.assertEqual(TestModel.objects.count(), 0)
+
+        response = self.client.post("/crud/tests/testmodels/create/", {"name": "Test text", "email": "sa@me.org"})
+        test_models = list(TestModel.objects.all())
+        self.assertEqual(len(test_models), 1)
+        self.assertEqual(response.url, "/crud/tests/testmodels/%s/" % test_models[0].pk)
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.post("/crud/tests/testmodels/1/update/", data={"name": "new_name"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/crud/tests/testmodels/%s/" % test_models[0].pk)
+
     def test_custom_detail_context(self):
         def custom_detail_context(self, request, context, **kwargs):
             context['testcontext'] = 'foo'

--- a/crudbuilder/views.py
+++ b/crudbuilder/views.py
@@ -144,6 +144,9 @@ class ViewBuilder(BaseBuilder):
             create_args
         )
 
+        if self.custom_get_success_url:
+            create_class.get_success_url = self.custom_get_success_url
+
         self.classes[name] = create_class
         return create_class
 
@@ -193,6 +196,10 @@ class ViewBuilder(BaseBuilder):
             tuple(parent_classes),
             update_args
         )
+        
+        if self.custom_get_success_url:
+            update_class.get_success_url = self.custom_get_success_url
+
         self.classes[name] = update_class
         return update_class
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -68,6 +68,10 @@ Then create the CRUD class for ``Person`` model::
             """Define your own custom context for detail view"""
             context['custom_data'] = "Some custom data"
             return context
+            
+        def custom_get_success_url(self, request):
+            """Define URL redirect after object is successfully created/updated"""
+            return reverse("tutorial-persons-detail", args=(self.object.pk, ))
 
         # permissions = {
         #     'list': 'example.person_list',


### PR DESCRIPTION
We sometimes had a problem that after we created some object, it will redirect us to the list of objects, but we wanted to be redirected to the detail on newly created object. So this PR is our solution for that.