### PR TITLE
V0.2.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Prerequisites
 -------------
 - Django 1.10+
 - Python 2.7+, 3.3+
-- Django Tables2 < 2.0
+- [Django Tables2](https://django-tables2.readthedocs.io/)
 
 Installation
 ------------

--- a/crudbuilder/__init__.py
+++ b/crudbuilder/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.8'
+VERSION = '0.2.9'


### PR DESCRIPTION
The crudbuilder seems to be compatible with django-tables2 once again. And we should release some new version on github and pupi.org with new changes.